### PR TITLE
Add k3d delete in the test section

### DIFF
--- a/docs/tutorials/kubernetes-101/prerequisites.md
+++ b/docs/tutorials/kubernetes-101/prerequisites.md
@@ -15,4 +15,5 @@ k3d cluster create k8s-101
 k3d kubeconfig get k8s-101 > k3d-kubeconfig.yaml
 export KUBECONFIG=$PWD/k3d-kubeconfig.yaml
 kubectl get namespaces
+k3d cluster delete k8s-101
 ```


### PR DESCRIPTION
When doing the Prerequisites, the first step after (Create k3d cluster) fails because the cluster has already been created.